### PR TITLE
Expand PHP proxy to handle queries and errors

### DIFF
--- a/php-implementation/README.md
+++ b/php-implementation/README.md
@@ -39,5 +39,5 @@ php client.php
 
 ## Limitations
 
-* We only reply with a resultset (for SELECT) or an OK packet (for other queries). Error packets are not yet implemented. Nuances of the query-specific expected response format are not yet implemented, too.
+* The proxy now returns resultsets, OK packets, or error packets depending on the executed query and responds to simple commands such as PING, QUIT, and INIT_DB.
 * `mysql` CLI client is unable to connect to the proxy server yet

--- a/php-implementation/handler-pdo.php
+++ b/php-implementation/handler-pdo.php
@@ -7,20 +7,25 @@ class PDOHandler implements MySQLQueryHandler {
 		$this->pdo = $pdo;
 	}
 
-	public function handleQuery(string $query): MySQLServerQueryResult {
-		// An extremely naive check. We should be using the MySQL parser to
-		// determine this:
-		if(!str_starts_with(strtolower($query), 'select')) {
-			$this->pdo->exec($query);
-			return new OkayPacketResult(
-				$this->pdo->rows_affected ?? 0,
-				$this->pdo->insert_id ?? 0
-			);
-		}
-		$rows = $this->pdo->query($query)->fetchAll(PDO::FETCH_ASSOC);
-		$columns = $this->computeColumnInfo($rows);
-		return new SelectQueryResult($columns, $rows);
-	}
+        public function handleQuery(string $query): MySQLServerQueryResult {
+                try {
+                        $stmt = $this->pdo->prepare($query);
+                        $stmt->execute();
+
+                        if ($stmt->columnCount() > 0) {
+                                $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                                $columns = $this->computeColumnInfo($rows);
+                                return new SelectQueryResult($columns, $rows);
+                        }
+
+                        return new OkayPacketResult(
+                                $stmt->rowCount(),
+                                (int)($this->pdo->lastInsertId() ?: 0)
+                        );
+                } catch (\Throwable $e) {
+                        return new ErrorQueryResult($e->getMessage());
+                }
+        }
 
 	public function computeColumnInfo($rows) {
 		if (empty($rows)) {

--- a/php-implementation/handler-sqlite-translation.php
+++ b/php-implementation/handler-sqlite-translation.php
@@ -25,20 +25,27 @@ class SQLiteTranslationHandler implements MySQLQueryHandler {
 		$this->wpdb = new WP_SQLite_DB();
 	}
 
-	public function handleQuery(string $query): MySQLServerQueryResult {
-		// An extremely naive check. We should be using the MySQL parser to
-		// determine this:
-		if(!str_starts_with(strtolower($query), 'select')) {
-			$this->wpdb->query($query);
-			return new OkayPacketResult(
-				$this->wpdb->rows_affected ?? 0,
-				$this->wpdb->insert_id ?? 0
-			);
-		}
-		$rows = $this->wpdb->get_results($query, ARRAY_A);
-		$columns = $this->computeColumnInfo($rows);
-		return new SelectQueryResult($columns, $rows);
-	}
+        public function handleQuery(string $query): MySQLServerQueryResult {
+                try {
+                        $result = $this->wpdb->query($query);
+                        if ($result === false) {
+                                return new ErrorQueryResult($this->wpdb->last_error ?: 'Unknown error');
+                        }
+
+                        if (!empty($this->wpdb->last_result)) {
+                                $rows = array_map(fn($row) => (array)$row, $this->wpdb->last_result);
+                                $columns = $this->computeColumnInfo($rows);
+                                return new SelectQueryResult($columns, $rows);
+                        }
+
+                        return new OkayPacketResult(
+                                $this->wpdb->rows_affected ?? 0,
+                                $this->wpdb->insert_id ?? 0
+                        );
+                } catch (\Throwable $e) {
+                        return new ErrorQueryResult($e->getMessage());
+                }
+        }
 
 	public function computeColumnInfo($rows) {
 		if (empty($rows)) {

--- a/php-implementation/mysql-server.php
+++ b/php-implementation/mysql-server.php
@@ -79,11 +79,13 @@ class MySQLProtocol {
 	 * 
 	 * @see https://dev.mysql.com/doc/dev/mysql-server/8.4.3/page_protocol_command_phase.html
 	 */
-	/** Tells the server that the client wants it to close the connection. */
-	const COM_QUIT                    = 0x01;
-	/** Tells the server to execute a query. */
+        /** Tells the server that the client wants it to close the connection. */
+        const COM_QUIT                    = 0x01;
+        /** Change the default schema. */
+        const COM_INIT_DB                = 0x02;
+        /** Tells the server to execute a query. */
     const COM_QUERY                   = 0x03;
-	/** Check if the server is alive. */
+        /** Check if the server is alive. */
     const COM_PING                    = 0x0E;
 	/** Tells the server to send the binlog dump. */
     const COM_BINLOG_DUMP             = 0x12;
@@ -314,6 +316,7 @@ class MySQLGateway {
     private $sequence_id;
     private $authenticated = false;
     private $buffer = '';
+    private $database = '';
 
     public function __construct(MySQLQueryHandler $query_handler) {
         $this->query_handler = $query_handler;
@@ -379,15 +382,30 @@ class MySQLGateway {
         
         // Otherwise, process as a command
         $command = ord($payload[0]);
-        if ($command === MySQLProtocol::COM_QUERY) {
-            $query = substr($payload, 1);
-            return $this->processQuery($query);
-        } else {
-            // Unsupported command
-            $errPacket = MySQLProtocol::buildErrPacket(0x04D2, "HY000", "Unsupported command");
-            return MySQLProtocol::encodeInt24(strlen($errPacket)) . 
-                   MySQLProtocol::encodeInt8(1) . 
-                   $errPacket;
+        switch ($command) {
+            case MySQLProtocol::COM_QUERY:
+                $query = substr($payload, 1);
+                return $this->processQuery($query);
+            case MySQLProtocol::COM_INIT_DB:
+                $schema = substr($payload, 1);
+                $this->database = $schema;
+                $okPacket = MySQLProtocol::buildOkPacket();
+                return MySQLProtocol::encodeInt24(strlen($okPacket)) .
+                       MySQLProtocol::encodeInt8(1) .
+                       $okPacket;
+            case MySQLProtocol::COM_PING:
+            case MySQLProtocol::COM_QUIT:
+                // Respond with a generic OK packet for simple commands like PING/QUIT
+                $okPacket = MySQLProtocol::buildOkPacket();
+                return MySQLProtocol::encodeInt24(strlen($okPacket)) .
+                       MySQLProtocol::encodeInt8(1) .
+                       $okPacket;
+            default:
+                // Unsupported command
+                $errPacket = MySQLProtocol::buildErrPacket(0x04D2, "HY000", "Unsupported command");
+                return MySQLProtocol::encodeInt24(strlen($errPacket)) .
+                       MySQLProtocol::encodeInt8(1) .
+                       $errPacket;
         }
     }
 
@@ -423,10 +441,10 @@ class MySQLGateway {
         try {
             $result = $this->query_handler->handleQuery($query);
             return $result->toPackets();
-        } catch (MySQLServerException $e) {
-            $errPacket = MySQLProtocol::buildErrPacket(0x04A7, "42000", "Syntax error or unsupported query: " . $e->getMessage());
-            return MySQLProtocol::encodeInt24(strlen($errPacket)) . 
-                   MySQLProtocol::encodeInt8(1) . 
+        } catch (\Throwable $e) {
+            $errPacket = MySQLProtocol::buildErrPacket(0x04A7, "HY000", $e->getMessage());
+            return MySQLProtocol::encodeInt24(strlen($errPacket)) .
+                   MySQLProtocol::encodeInt8(1) .
                    $errPacket;
         }
     }
@@ -440,6 +458,7 @@ class MySQLGateway {
         $this->sequence_id = 0;
         $this->authenticated = false;
         $this->buffer = '';
+        $this->database = '';
     }
     
     /**


### PR DESCRIPTION
## Summary
- Extend command handling to respond to PING, QUIT, and INIT_DB and return ERR packets for unsupported commands.
- Handle query failures gracefully, emitting MySQL error packets from the server and from PDO/SQLite handlers.
- Update documentation to note support for error packets and basic command responses.

## Testing
- `php -l php-implementation/mysql-server.php`
- `php -l php-implementation/handler-pdo.php`
- `php -l php-implementation/handler-sqlite-translation.php`


------
https://chatgpt.com/codex/tasks/task_e_689a6add47b08328a7984e378e3b9681